### PR TITLE
Reference the npm package directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ root of your project and add an `extends` property:
 
 ```json
 {
-  "extends": "node_modules/@dolittle/build/.babelrc"
+  "extends": "@dolittle/build/.babelrc"
 }
 ```
 
@@ -159,7 +159,7 @@ To add plugins or presets, you can simply add a `plugins` or `presets` property 
 
 ```json
 {
-  "extends": "node_modules/@dolittle/build/.babelrc",
+  "extends": "@dolittle/build/.babelrc",
   "plugins": [ ... ],
   "presets": [ ... ]
 }


### PR DESCRIPTION
Either you can use the absolute path to the file in question using `./node_modules/...`, or reference the npm package. I think we should prefer the npm by default.